### PR TITLE
fix error ‘bind’ is not a member of ‘std’

### DIFF
--- a/src/ilogger.cpp
+++ b/src/ilogger.cpp
@@ -18,6 +18,7 @@
 #include <fstream>
 #include <stack>
 #include <signal.h>
+#include <functional>
 
 #if defined(U_OS_WINDOWS)
 #	define HAS_UUID


### PR DESCRIPTION
add header file `functional` to avoid error ‘bind’ is not a member of ‘std’ mentioned in https://github.com/shouxieai/http_server_cpp/issues/1